### PR TITLE
fix  highlighting text when dragging (Browser: IE)

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -27,6 +27,9 @@ export function mousedown(e){
 		document.addEventListener('mousemove', events.mousemove, false);
 		document.addEventListener('mouseup', events.mouseup, false);
 	}
+
+	// prevent highlighting text when dragging (IE)
+	e.preventDefault();
 };
 
 export function mousemove(offsetW, offsetH, e){


### PR DESCRIPTION
Hello!

Thank you for sharing a great 'Drag & Drop' library.

When I used it for my studying project,  accidently found a minor problem.

When using IE, text highlightning problem was occured. So I put 'preventDefault' at the end of  the function named 'mousedown'.

Thank you!