### PR TITLE
typescript error message 

### DIFF
--- a/src/displace.d.ts
+++ b/src/displace.d.ts
@@ -4,9 +4,9 @@ declare module 'displacejs' {
 
 type DisplaceJSObject = {
   // Runs setup again. Useful when divs have been moved or resized.
-  reinit: function(): void,
+  reinit: () => void
   // Removes event listeners and destroys instance.
-  destroy: function(): void
+  destroy: () => void
 };
 
 type DisplaceJSOptions = {


### PR DESCRIPTION
Hi,
I am getting error on 

type DisplaceJSObject = {
  // Runs setup again. Useful when divs have been moved or resized.
  reinit: function(): void,
  // Removes event listeners and destroys instance.
  destroy: function(): void
};

JSDoc types can only be used inside documentation comments

thanks